### PR TITLE
Enhance darts game rules for 301/501/701

### DIFF
--- a/Darts_Score_Management/Controllers/GameRulesController.cs
+++ b/Darts_Score_Management/Controllers/GameRulesController.cs
@@ -38,10 +38,12 @@ namespace Darts_Score_Management.Controllers
         {
             try
             {
-                if (throws == null || throws.Count != 3)
-                {
-                    return BadRequest(new { message = "A turn must contain exactly 3 throws" });
-                }
+                //if (throws == null || throws.Count != 3)
+                //{
+                //    return BadRequest(new { message = "A turn must contain exactly 3 throws" });
+                //}
+                if (throws == null || throws.Count > 3)
+                    throw new GameRuleViolationException("A turn must contain 0 to 3 throws", "ThrowCount");
 
 
                 var gameState = await _gameRulesEngine.ProcessTurnForLeg(legId, throws);

--- a/Darts_Score_Management/DTOs/Throw/CreateThrowDTO.cs
+++ b/Darts_Score_Management/DTOs/Throw/CreateThrowDTO.cs
@@ -11,7 +11,7 @@ namespace Darts_Score_Management.DTOs.Throw
 
         [Required]
         // [Range(0, 25)]
-        [ValidDartSegment]
+        //[ValidDartSegment]
         public int Segment { get; set; }
 
         [Required]

--- a/Darts_Score_Management/Services/GameRulesEngine.cs
+++ b/Darts_Score_Management/Services/GameRulesEngine.cs
@@ -191,9 +191,18 @@ namespace Darts_Score_Management.Services
             for (int i = 0; i < throws.Count; i++)
             {
                 var throwDto = throws[i];
+                if (!IsValidDartSegment(throwDto.Segment, throwDto.Multiplier))
+                {
+                    return new BustAnalysisResult
+                    {
+                        HasBust = true,
+                        BustIndex = i,
+                        BustMessage = "Invalid dart segment or multiplier"
+                    };
+                }
                 int points = CalculatePoints(throwDto.Segment, throwDto.Multiplier);
-                int newScore = simulatedScore - points;
-
+                int newScore = simulatedScore - points; 
+                var game = _gameService.GetGameByIdAsync(turn.Leg.Set.GameId).Result;
                 // Check for bust conditions
                 if (newScore < 0)
                 {
@@ -205,10 +214,19 @@ namespace Darts_Score_Management.Services
                     };
                 }
 
+                if (newScore == 1 && game.Settings.MustFinishOnDouble)
+                {
+                    return new BustAnalysisResult
+                    {
+                        HasBust = true,
+                        BustIndex = i,
+                        BustMessage = "Bust - cannot finish on 1 with finish-on-double rule"
+                    };
+                }
+
                 // Check for finish-on-double rule
                 if (newScore == 0)
                 {
-                    var game = _gameService.GetGameByIdAsync(turn.Leg.Set.GameId).Result;
                     if (game.Settings.MustFinishOnDouble && throwDto.Multiplier != 2)
                     {
                         return new BustAnalysisResult
@@ -609,9 +627,10 @@ namespace Darts_Score_Management.Services
 
         private bool IsValidDartSegment(int segment, int multiplier)
         {
+           if (segment == 0 && multiplier == 1) return true;
            if (segment < 1 || (segment > 20 && segment != 25)) return false;
            if (multiplier < 1 || multiplier > 3) return false;
-           if (segment == 25 && multiplier > 2) return false; // Bullseye can only be single or double
+           if (segment == 25 && multiplier > 2) return false; 
            return true;
         }
 

--- a/Darts_Score_Management/ValidationAttributes/ValidDartSegmentAttribute.cs
+++ b/Darts_Score_Management/ValidationAttributes/ValidDartSegmentAttribute.cs
@@ -1,19 +1,19 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿//using System.ComponentModel.DataAnnotations;
 
-namespace Darts_Score_Management.ValidationAttributes
-{
-    public class ValidDartSegmentAttribute : ValidationAttribute
-    {
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-        {
-            if (value is int segment)
-            {
-                if ((segment >= 1 && segment <= 20) || segment == 25)
-                    return ValidationResult.Success;
+//namespace Darts_Score_Management.ValidationAttributes
+//{
+//    public class ValidDartSegmentAttribute : ValidationAttribute
+//    {
+//        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+//        {
+//            if (value is int segment)
+//            {
+//                if ((segment >= 1 && segment <= 20) || segment == 25)
+//                    return ValidationResult.Success;
 
-                return new ValidationResult("Invalid dart segment. Must be between 1-20 or 25 for bullseye.");
-            }
-            return new ValidationResult("Segment must be an integer.");
-        }
-    }
-}
+//                return new ValidationResult("Invalid dart segment. Must be between 1-20 or 25 for bullseye.");
+//            }
+//            return new ValidationResult("Segment must be an integer.");
+//        }
+//    }
+//}


### PR DESCRIPTION
### **User description**
- Restrict bullseye (25) to multipliers 1 or 2 in `IsValidDartSegment`.
- Allow `Segment = 0, Multiplier = 1` for misses in `IsValidDartSegment`.
- Support 0-3 throws per turn in controller.
- Mark score of 1 as bust with double-out in `AnalyzeThrowsForBust`.
- Remove `ValidDartSegmentAttribute` to enable miss throws.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Updated dart game rules to allow 0-3 throws per turn.

- Enhanced validation for dart segments and multipliers.

- Improved bust analysis logic for double-out and invalid throws.

- Deprecated `ValidDartSegmentAttribute` to support miss throws.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GameRulesController.cs</strong><dd><code>Allow 0-3 throws per turn in controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Darts_Score_Management/Controllers/GameRulesController.cs

<li>Modified turn validation to allow 0-3 throws.<br> <li> Replaced hard validation error with exception handling.


</details>


  </td>
  <td><a href="https://github.com/stenlinajazi/Darts_Score_Management/pull/5/files#diff-12966c742f6c605f6d9d75a02c9ee519ee9caee30589fcb2f544398ce8be7dc5">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CreateThrowDTO.cs</strong><dd><code>Remove `ValidDartSegment` validation from DTO</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Darts_Score_Management/DTOs/Throw/CreateThrowDTO.cs

<li>Commented out <code>ValidDartSegment</code> validation attribute.<br> <li> Prepared DTO for updated validation logic.


</details>


  </td>
  <td><a href="https://github.com/stenlinajazi/Darts_Score_Management/pull/5/files#diff-c30dba47ed29d6ecea291509c5706c645853d39da3bbce902b55d4652cf30f90">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GameRulesEngine.cs</strong><dd><code>Improve bust analysis and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Darts_Score_Management/Services/GameRulesEngine.cs

<li>Added validation for dart segments and multipliers.<br> <li> Enhanced bust analysis for double-out and invalid throws.<br> <li> Incorporated game settings into bust logic.


</details>


  </td>
  <td><a href="https://github.com/stenlinajazi/Darts_Score_Management/pull/5/files#diff-c0dc5840f56b16c0491800dc72644fe9bef912d6bb8c4144d12b27f6ef052ca7">+23/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ValidDartSegmentAttribute.cs</strong><dd><code>Deprecate `ValidDartSegmentAttribute` for validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Darts_Score_Management/ValidationAttributes/ValidDartSegmentAttribute.cs

<li>Deprecated <code>ValidDartSegmentAttribute</code> by commenting out its <br>implementation.<br> <li> Removed dependency on this attribute for validation.


</details>


  </td>
  <td><a href="https://github.com/stenlinajazi/Darts_Score_Management/pull/5/files#diff-01a88e169cb6e9b2418d9fcf6ffd7f64cc495637f44be918cccf741793005207">+17/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated turn processing now supports 0 to 3 throws, providing clearer feedback when too many throws are attempted.
  - Enhanced scoring rules enforce stricter checks on dart segments and multipliers, ensuring fair bust detection, including when finishing conditions aren’t met.

- **Refactor**
  - Relaxed legacy dart segment validations for a streamlined gameplay experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->