### PR TITLE
Refactor player ranking in EndGameAsync using precomputed EndingScore…

### DIFF
--- a/Darts_Score_Management/Services/GameService.cs
+++ b/Darts_Score_Management/Services/GameService.cs
@@ -15,14 +15,16 @@ namespace Darts_Score_Management.Services
         private readonly IMapper _mapper;
         private readonly ISetService _setService;
         private readonly ILegService _legService;
+        private readonly ITurnService _turnService;
 
         public GameService(IGameRepository gameRepository, IMapper mapper, ISetService setService,
-            ILegService legService)
+            ILegService legService, ITurnService turnService)
         {
             _gameRepository = gameRepository;
             _mapper = mapper;
             _setService = setService;
             _legService = legService;
+            _turnService = turnService;
         }
         public async Task<IEnumerable<GameDTO>> GetAllGamesAsync()
         {
@@ -113,19 +115,38 @@ namespace Darts_Score_Management.Services
             game.EndedAt = DateTime.UtcNow;
 
             // Set winner and rankings
-            var gamePlayers = game.GamePlayers.OrderBy(gp => gp.TurnOrder).ToList();
-            int ranking = 1;
-
-            // Set winner's ranking (rank 1) and mark as winner
+            var gamePlayers = game.GamePlayers.ToList();
             var winner = gamePlayers.FirstOrDefault(gp => gp.PlayerId == winnerId);
             if (winner != null)
             {
                 winner.IsWinner = true;
-                winner.FinalRanking = ranking++;
+                winner.FinalRanking = 1;
             }
 
-            // Set rankings for losers (rank 2, 3, etc.) based on TurnOrder
-            foreach (var player in gamePlayers.Where(gp => gp.PlayerId != winnerId))
+            // Get the latest leg in the game (last set, last leg)
+            var latestLeg = game.Sets
+                .OrderByDescending(s => s.SetNumber)
+                .SelectMany(s => s.Legs)
+                .OrderByDescending(l => l.LegNumber)
+                .FirstOrDefault();
+
+            if (latestLeg == null)
+                throw new InvalidOperationException("No legs found in the game");
+
+            // Fetch ending scores for all players from their last turn in the latest leg
+            var playerScores = new Dictionary<int, int>();
+            foreach (var player in gamePlayers)
+            {
+                var lastTurnDto = await _turnService.GetLastTurnByPlayerAndLegAsync(player.PlayerId, latestLeg.Id);
+                int endingScore = lastTurnDto?.EndingScore ?? game.StartingScore;
+                playerScores[player.PlayerId] = endingScore;
+            }
+
+            // Rank losers based on ending score (ascending: least points = higher rank)
+            int ranking = 2;
+            foreach (var player in gamePlayers
+                .Where(gp => gp.PlayerId != winnerId)
+                .OrderBy(gp => playerScores[gp.PlayerId]))
             {
                 player.FinalRanking = ranking++;
             }


### PR DESCRIPTION
### **User description**
… from latest leg turns


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored `EndGameAsync` to use precomputed ending scores.

- Introduced `ITurnService` to fetch player turn data.

- Adjusted player ranking logic based on ending scores.

- Added error handling for missing legs in a game.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>GameService.cs</strong><dd><code>Refactored EndGameAsync and improved ranking logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Darts_Score_Management/Services/GameService.cs

<li>Added <code>ITurnService</code> dependency for fetching turn data.<br> <li> Refactored <code>EndGameAsync</code> to calculate rankings using ending scores.<br> <li> Implemented logic to fetch latest leg and player scores.<br> <li> Enhanced error handling for missing legs in the game.


</details>


  </td>
  <td><a href="https://github.com/stenlinajazi/Darts_Score_Management/pull/6/files#diff-42c2dbe9b657733c8983d515d5a162ee1811e66b87342422572d3e57b5434108">+29/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced end-game scoring: The final scores now reflect an improved ranking system that always highlights the winner at the top.
  - Fairer player standings: Remaining players are ordered based on their end-game scores for a consistent and accurate presentation of results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->